### PR TITLE
Update public directory source for keycloak-theme

### DIFF
--- a/scripts/prepare-publish.js
+++ b/scripts/prepare-publish.js
@@ -18,7 +18,7 @@ const DEPS_TO_EXCLUDE = [
 const DIRS_TO_COPY = [
     { src: "src/login", dest: "keycloak-theme/login" },
     { src: "src/components", dest: "keycloak-theme/components" },
-    { src: "public", dest: "keycloak-theme/public" },
+    { src: "public/keycloak-theme", dest: "keycloak-theme/public" },
     { src: "README.md", dest: "README.md" }
 ];
 


### PR DESCRIPTION
Hello @Oussemasahbeni,  

There's a bug in the public imports.  
If you want the favicon to be included as well you need to move them. Keycloakify do not allow you to copy things directly at the root of the user's project.  